### PR TITLE
Change pt hd aq

### DIFF
--- a/src/main/java/gov/nih/nci/ui/NCIEditTab.java
+++ b/src/main/java/gov/nih/nci/ui/NCIEditTab.java
@@ -2231,7 +2231,7 @@ public class NCIEditTab extends OWLWorkspaceViewsTab implements ClientSessionLis
     		for (OWLAnnotationProperty prop : req_props) {
     			String new_val = ann_vals.get(prop.getIRI().getShortForm());
 
-    			if (!new_val.isEmpty()) {
+    			if (new_val != null && !new_val.isEmpty()) {
     				OWLAnnotation new_ann = df.getOWLAnnotation(prop, df.getOWLLiteral(new_val));
     				new_anns.add(new_ann);
 
@@ -2261,7 +2261,7 @@ public class NCIEditTab extends OWLWorkspaceViewsTab implements ClientSessionLis
 
     		for (OWLAnnotationProperty prop : req_props) {
     			String val = ann_vals.get(prop.getIRI().getShortForm());
-    			if (!val.isEmpty()) {
+    			if (val != null && !val.isEmpty()) {
     				OWLAnnotation new_ann = df.getOWLAnnotation(prop, df.getOWLLiteral(val));
     				anns.add(new_ann);
 

--- a/src/main/java/gov/nih/nci/ui/NCIEditTab.java
+++ b/src/main/java/gov/nih/nci/ui/NCIEditTab.java
@@ -2218,7 +2218,7 @@ public class NCIEditTab extends OWLWorkspaceViewsTab implements ClientSessionLis
     		for (OWLAnnotation annax : anns) {
     			String cv = annax.getProperty().getIRI().getShortForm();
     			String new_val = ann_vals.get(cv);
-    			if (!new_val.isEmpty()) {
+    			if (new_val != null && !new_val.isEmpty()) {
 
     				OWLAnnotation new_ann = df.getOWLAnnotation(annax.getProperty(), df.getOWLLiteral(new_val));
     				new_anns.add(new_ann); 


### PR DESCRIPTION
The business rules governing `FULL_SYN` are:

 * one and only one `FULL_SYN` with `term-group` `PT` is required

 * `PT`, `AQ`, and `HD` are the same, any can be used

This bug was that the user could not change the existing `FULL_SYN's` 'term-group` from `PT` to `HD` without having it reset. The user can also change the `preferred_name` which further complicates syncing of the `FULL_SYN`, `preferred_name`, and `rdfs:label`